### PR TITLE
Uses new RMT driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,6 @@ The example is provided and tested using Arduino 3.0.0 based on ESP-IDF 5.1.4
 
 * Version 1.x is for Arduino 2.x based on ESP-IDF 4.x
 * Version 2.x is for Arduino 3.0.0 based on ESP-IDF 5.1.4
-
-The new RMT driver does not require channel, please remove the last parameter from read_dht() if you are upgrading.
-Also you cannot use deprecated rmt.h and rmt_rx.h (idf 5.x) together as it will cause bootloop.
-
 ---
 
 <a href="https://www.buymeacoffee.com/htmltiger"><img src="https://www.buymeacoffee.com/assets/img/custom_images/white_img.png" alt="Buy Me A Coffee"></a>

--- a/README.md
+++ b/README.md
@@ -5,7 +5,14 @@ This is a minimal library with just one function to get the reading, it is using
 
 This library is a non-blocking and does not use any CPU delays or disable interrupts, can also be used with other RTM libraries as it installs the driver as shared and gets the readings and uninstall it after every readings.
 
-The example is provided and tested using Arduino 2.0.6 based on ESP-IDF 4.4.3
+The example is provided and tested using Arduino 3.0.0 based on ESP-IDF 5.1.4
+
+* Version 1.x is for Arduino 2.x based on ESP-IDF 4.x
+* Version 2.x is for Arduino 3.0.0 based on ESP-IDF 5.1.4
+
+The new RMT driver does not require channel, please remove the last parameter from read_dht() if you are upgrading.
+Also you cannot use deprecated rmt.h and rmt_rx.h (idf 5.x) together as it will cause bootloop.
+
 ---
 
 <a href="https://www.buymeacoffee.com/htmltiger"><img src="https://www.buymeacoffee.com/assets/img/custom_images/white_img.png" alt="Buy Me A Coffee"></a>

--- a/dhtESP32-rmt.cpp
+++ b/dhtESP32-rmt.cpp
@@ -3,111 +3,106 @@
 #include <Arduino.h>
 #include "dhtESP32-rmt.h"
 
-uint8_t read_dht(float &temperature, float &humidity, uint8_t pin, uint8_t dhttype, uint8_t rx){
-	//check last read
-	static uint8_t devices = 1;
-	struct pin_grp {
-		uint8_t id;
-		unsigned long lastRead;
-	};
-	static pin_grp *pins = new pin_grp[1]{{pin, 0}};
-	int8_t devid = -1;
-	for(int i = 0; i < devices; i++){if(pins[i].id == pin){devid = i;break;}}
-	if (devid == -1) {
-		pin_grp* tmp_pin = new pin_grp[devices + 1];
-		for(int i = 0; i < devices; i++){tmp_pin[i] = pins[i];}
-		tmp_pin[devices].id = pin;
-		devid = devices;
-		delete[] pins;
-		pins = tmp_pin;
-		devices++;
-	}
-	if(pins[devid].lastRead && millis() - pins[devid].lastRead < (dhttype == DHT22 ? 2000 : 1000)){
-		return DHT_TOO_SOON;
-	}
-	pins[devid].lastRead = millis();
-	//end
-	
+uint8_t read_dht(float &temperature, float &humidity, uint8_t pin, uint8_t dhttype) {
 	gpio_num_t dhtpin = static_cast<gpio_num_t>(pin);
-	rmt_channel_t dhtrx = static_cast<rmt_channel_t>(rx);
-	rmt_config_t rmt_rx = {
-		.rmt_mode = RMT_MODE_RX,
-		.channel = dhtrx,
-		.gpio_num = dhtpin,
-		.clk_div = 80,
-		.mem_block_num = 1,
-		.flags = 0,
-		.rx_config = {
-			.idle_threshold = 250,
-			.filter_ticks_thresh = 30,
-			.filter_en = true,
-		}
+	rmt_channel_handle_t rx_channel = NULL;
+	rmt_symbol_word_t symbols[64];
+	rmt_rx_done_event_data_t rx_data;
+	
+	rmt_receive_config_t rx_config = {
+		.signal_range_min_ns = 3000,
+		.signal_range_max_ns = 150000,
 	};
-	if(rmt_config(&rmt_rx) == ESP_OK && rmt_driver_install(rmt_rx.channel, 512, ESP_INTR_FLAG_LOWMED | ESP_INTR_FLAG_IRAM | ESP_INTR_FLAG_SHARED) == ESP_OK){
-		RingbufHandle_t dhtbuf;
-		rmt_get_ringbuf_handle(dhtrx, &dhtbuf);
-		gpio_set_level(dhtpin, 1);
-		gpio_pullup_dis(dhtpin);
-		gpio_pulldown_dis(dhtpin);
-		gpio_set_direction(dhtpin, GPIO_MODE_INPUT_OUTPUT_OD);
-		gpio_set_intr_type(dhtpin, GPIO_INTR_DISABLE);
-		gpio_set_level(dhtpin, 0);
-		vTaskDelay((dhttype == DHT22 ? 2 : 22) / portTICK_PERIOD_MS);
-		gpio_set_level(dhtpin, 1);
-		rmt_rx_start(dhtrx, true);
-		size_t rx_size;
-		rmt_item32_t *rx_items = (rmt_item32_t *)xRingbufferReceive(dhtbuf, &rx_size, pdMS_TO_TICKS(100));
-		uint8_t error = DHT_OK;
-		if(rx_items){
-			int tot_items = rx_size / sizeof(rmt_item32_t);
-			uint8_t pulse = rx_items[0].duration0 + rx_items[0].duration1;
-			if(tot_items < 41){
-				error = DHT_UNDERFLOW;
-			}else if(tot_items > 42){
-				error = DHT_OVERFLOW;
-			}else if((pulse) < 130 || (pulse) > 180){
-				error = DHT_NACK;
-			}else{
-				uint8_t data[6];
-				for(uint8_t i = 0; i < 40; i++){
-					pulse = rx_items[i+1].duration0 + rx_items[i+1].duration1;
-					if(pulse > 55 && pulse < 145){
-						data[i / 8] <<= 1;
-						if(pulse > 110){
-							data[i / 8] |= 1;
-						}
-					}else{
-						error = DHT_BAD_DATA;
+	
+	rmt_rx_channel_config_t rx_ch_conf = {
+		.gpio_num = dhtpin,
+		.clk_src = RMT_CLK_SRC_DEFAULT,
+		.resolution_hz = 1000000,
+		.mem_block_symbols = 64,
+	};
+	uint8_t error = DHT_OK;
+	if(rmt_new_rx_channel(&rx_ch_conf, &rx_channel) != ESP_OK) {
+		return DHT_DRIVER;
+	}
+	QueueHandle_t rx_queue = xQueueCreate(1, sizeof(rx_data));
+	assert(rx_queue);
+	rmt_rx_event_callbacks_t cbs = {
+		.on_recv_done = dhtrx_done,
+	};
+
+	rmt_rx_register_event_callbacks(rx_channel, &cbs, rx_queue);
+
+	gpio_set_level(dhtpin, 1);
+	gpio_pullup_dis(dhtpin);
+	gpio_pulldown_dis(dhtpin);
+	gpio_set_direction(dhtpin, GPIO_MODE_INPUT_OUTPUT_OD);
+	gpio_set_intr_type(dhtpin, GPIO_INTR_DISABLE);
+	gpio_set_level(dhtpin, 0);
+	vTaskDelay((dhttype == DHT22 ? 2 : 22) / portTICK_PERIOD_MS);
+	gpio_set_level(dhtpin, 1);
+	
+	
+	if(rmt_enable(rx_channel) || rmt_receive(rx_channel, symbols, sizeof(symbols), &rx_config) != ESP_OK ) {
+		return DHT_DRIVER;
+	}
+
+	if (xQueueReceive(rx_queue, &rx_data, pdMS_TO_TICKS(100)) == pdPASS) {
+		
+		char buf[128];
+		size_t len = rx_data.num_symbols;
+
+		uint32_t code = 0;
+		rmt_symbol_word_t *cur = rx_data.received_symbols;
+		uint8_t pulse = cur[0].duration0 + cur[0].duration1;
+		if(len < 41){
+			error = DHT_UNDERFLOW;
+		}else if(len > 42){
+			error = DHT_OVERFLOW;
+		}else if((pulse) < 130 || (pulse) > 180){
+			error = DHT_NACK;
+		}else{
+			uint8_t data[6];
+			for(uint8_t i = 0; i < 40; i++){
+				pulse = cur[i+1].duration0 + cur[i+1].duration1;
+				if(pulse > 55 && pulse < 145){
+					data[i / 8] <<= 1;
+					if(pulse > 110){
+						data[i / 8] |= 1;
 					}
-				}
-				if(!error){
-					uint8_t total = data[0] + data[1] + data[2] + data[3];
-					if(data[4] == total){
-						if(dhttype == DHT22){
-							humidity = (data[0] * 256 + data[1]) * 0.1;
-							temperature = ((data[2] & 0x7f) * 256 + data[3]) * 0.1;
-							if(data[2] & 0x80){temperature = -temperature;}
-						}else{
-							humidity = data[0];
-							temperature = data[2];
-						}
-					}else{
-						error = DHT_CHECKSUM;
-					}
+				}else{
+					error = DHT_BAD_DATA;
 				}
 			}
-			vRingbufferReturnItem(dhtbuf, (void *)rx_items);
-		}else{
-			error = DHT_TIMEOUT;
+			if(!error){
+				uint8_t total = data[0] + data[1] + data[2] + data[3];
+				if(data[4] == total){
+					if(dhttype == DHT22){
+						humidity = (data[0] * 256 + data[1]) * 0.1;
+						temperature = ((data[2] & 0x7f) * 256 + data[3]) * 0.1;
+						if(data[2] & 0x80){temperature = -temperature;}
+					}else{
+						humidity = data[0];
+						temperature = data[2];
+					}
+				}else{
+					error = DHT_CHECKSUM;
+				}
+			}
 		}
-		gpio_set_level(dhtpin, 1);
-		rmt_rx_stop(dhtrx);
-		rmt_driver_uninstall(dhtrx);
-		return error;
+	} else {
+		error = DHT_TIMEOUT;
 	}
-	return DHT_DRIVER;
+
+	gpio_set_level(dhtpin, 1);
+	vQueueDelete(rx_queue);
+	rmt_disable(rx_channel);
+	rmt_del_channel(rx_channel);
+	return error;
 }
 
-
-
-
+bool dhtrx_done(rmt_channel_handle_t ch, const rmt_rx_done_event_data_t *edata, void *udata){
+	BaseType_t w = pdFALSE;
+	QueueHandle_t d = (QueueHandle_t)udata;
+	xQueueSendFromISR(d, edata, &w);
+	return w == pdTRUE;
+}

--- a/dhtESP32-rmt.h
+++ b/dhtESP32-rmt.h
@@ -1,8 +1,12 @@
-// https://github.com/htmltiger/dhtESP32-rmt
+// https://github.com/junkfix/dhtESP32-rmt
 #pragma once
 
 #include <Arduino.h>
-#include "driver/rmt.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "freertos/queue.h"
+#include "driver/rmt_rx.h"
+#include "driver/gpio.h"
 
 #define DHT11	0
 #define DHT21	1
@@ -20,4 +24,6 @@
 #define DHT_UNDERFLOW	7
 #define DHT_OVERFLOW	8
 
-uint8_t read_dht(float &temperature, float &humidity, uint8_t pin, uint8_t dhttype = DHT22, uint8_t rx= 1);
+uint8_t read_dht(float &temperature, float &humidity, uint8_t pin, uint8_t dhttype);
+
+bool dhtrx_done(rmt_channel_handle_t channel, const rmt_rx_done_event_data_t *edata, void *udata);

--- a/examples/dht22/dht22.ino
+++ b/examples/dht22/dht22.ino
@@ -1,4 +1,4 @@
-// https://github.com/htmltiger/dhtESP32-rmt
+// https://github.com/junkfix/dhtESP32-rmt
 
 #include <dhtESP32-rmt.h>
 
@@ -8,7 +8,7 @@ float humidity = 0.0;
 /*
 void tempTask(void *pvParameters){
 	for(;;){
-		uint8_t error=read_dht(temperature, humidity, 13, DHT22, 1);
+		uint8_t error=read_dht(temperature, humidity, 13, DHT22);
 		if(error){
 			Serial.println(error);
 		}else{
@@ -27,8 +27,8 @@ void setup() {
 }
 
 void loop() {
-	//read_dht(temperature, humidity, pin, type (DHT11, DHT21, DHT22, AM2301, AM2302), RMT channel (0-7) 
-	uint8_t error=read_dht(temperature, humidity, 13, DHT22, 0);
+	//read_dht( temperature, humidity, pin, type (DHT11, DHT21, DHT22, AM2301, AM2302) )
+	uint8_t error=read_dht(temperature, humidity, 13, DHT22);
 	if(error){
 		Serial.println(error);
 	}else{

--- a/library.properties
+++ b/library.properties
@@ -1,8 +1,8 @@
 name=dhtESP32-rmt
-version=1.0.0
+version=2.0.0
 author=junkfix
 maintainer=junkfix
-sentence=Minimal, non-blocking, DHT11/DHT22 sensor library for ESP32 using RMT pheripheral
+sentence=Minimal, non-blocking, DHT11/DHT22 sensor library for ESP32 using RMT pheripheral for Arduino 3.0.0 based on ESP-IDF v5.1.4
 paragraph=
 category=Sensors
 url=https://github.com/junkfix/dhtESP32-rmt


### PR DESCRIPTION
BREAKING CHANGE:

* The new RMT driver does not require channel, please remove the last parameter from read_dht() if you are upgrading.
* Also you cannot use deprecated rmt.h and rmt_rx.h (idf 5.x) together as it will cause bootloop.